### PR TITLE
v5.6 build fix

### DIFF
--- a/driver/src/devicedrv/mali/linux/mali_memory_cow.c
+++ b/driver/src/devicedrv/mali/linux/mali_memory_cow.c
@@ -683,7 +683,7 @@ void _mali_mem_cow_copy_page(mali_page_node *src_node, mali_page_node *dst_node)
 		/*
 		* use ioremap to map src for BLOCK memory
 		*/
-		src = ioremap_nocache(_mali_page_node_get_dma_addr(src_node), _MALI_OSK_MALI_PAGE_SIZE);
+		src = ioremap(_mali_page_node_get_dma_addr(src_node), _MALI_OSK_MALI_PAGE_SIZE);
 		memcpy(dst, src , _MALI_OSK_MALI_PAGE_SIZE);
 		iounmap(src);
 	}

--- a/driver/src/devicedrv/mali/linux/mali_osk_low_level_mem.c
+++ b/driver/src/devicedrv/mali/linux/mali_osk_low_level_mem.c
@@ -33,7 +33,7 @@ void _mali_osk_write_mem_barrier(void)
 
 mali_io_address _mali_osk_mem_mapioregion(uintptr_t phys, u32 size, const char *description)
 {
-	return (mali_io_address)ioremap_nocache(phys, size);
+	return (mali_io_address)ioremap(phys, size);
 }
 
 void _mali_osk_mem_unmapioregion(uintptr_t phys, u32 size, mali_io_address virt)

--- a/driver/src/devicedrv/mali/platform/arm/arm.c
+++ b/driver/src/devicedrv/mali/platform/arm/arm.c
@@ -96,7 +96,7 @@ static int mali_secure_mode_init_juno(void)
 
 	MALI_DEBUG_ASSERT(NULL == secure_mode_mapped_addr);
 
-	secure_mode_mapped_addr = ioremap_nocache(phys_addr_page, map_size);
+	secure_mode_mapped_addr = ioremap(phys_addr_page, map_size);
 	if (NULL != secure_mode_mapped_addr) {
 		return mali_gpu_reset_and_secure_mode_disable_juno();
 	}
@@ -576,7 +576,7 @@ static u32 mali_read_phys(u32 phys_addr)
 	u32 phys_offset    = phys_addr & 0x00001FFF;
 	u32 map_size       = phys_offset + sizeof(u32);
 	u32 ret = 0xDEADBEEF;
-	void *mem_mapped = ioremap_nocache(phys_addr_page, map_size);
+	void *mem_mapped = ioremap(phys_addr_page, map_size);
 	if (NULL != mem_mapped) {
 		ret = (u32)ioread32(((u8 *)mem_mapped) + phys_offset);
 		iounmap(mem_mapped);
@@ -591,7 +591,7 @@ static void mali_write_phys(u32 phys_addr, u32 value)
 	u32 phys_addr_page = phys_addr & 0xFFFFE000;
 	u32 phys_offset    = phys_addr & 0x00001FFF;
 	u32 map_size       = phys_offset + sizeof(u32);
-	void *mem_mapped = ioremap_nocache(phys_addr_page, map_size);
+	void *mem_mapped = ioremap(phys_addr_page, map_size);
 	if (NULL != mem_mapped) {
 		iowrite32(value, ((u8 *)mem_mapped) + phys_offset);
 		iounmap(mem_mapped);


### PR DESCRIPTION
This PR fixes building after the commit [remove ioremap_nocache and devm_ioremap_nocache](https://github.com/torvalds/linux/commit/1188dd7d3fbd367daa90da1b0c707f8e1e61c1ba) in linux-next.

> ioremap has provided non-cached semantics by default since the Linux 2.6
> days, so remove the additional ioremap_nocache interface.