### PR TITLE
update for 5.6 timespec changes

### DIFF
--- a/driver/src/devicedrv/mali/linux/mali_osk_time.c
+++ b/driver/src/devicedrv/mali/linux/mali_osk_time.c
@@ -53,5 +53,5 @@ u64 _mali_osk_time_get_ns(void)
 
 u64 _mali_osk_boot_time_get_ns(void)
 {
-	return ktime_get_boottime_ns;
+	return ktime_get_boottime_ns();
 }

--- a/driver/src/devicedrv/mali/linux/mali_osk_time.c
+++ b/driver/src/devicedrv/mali/linux/mali_osk_time.c
@@ -46,7 +46,9 @@ void _mali_osk_time_ubusydelay(u32 usecs)
 
 u64 _mali_osk_time_get_ns(void)
 {
-	return timespec64_to_ns;
+	struct timespec64 ts64;
+	ktime_get_real_ts64(&ts64);
+	return timespec64_to_ns(&ts64);
 }
 
 u64 _mali_osk_boot_time_get_ns(void)

--- a/driver/src/devicedrv/mali/linux/mali_osk_time.c
+++ b/driver/src/devicedrv/mali/linux/mali_osk_time.c
@@ -46,12 +46,10 @@ void _mali_osk_time_ubusydelay(u32 usecs)
 
 u64 _mali_osk_time_get_ns(void)
 {
-	struct timespec tsval;
-	getnstimeofday(&tsval);
-	return (u64)timespec_to_ns(&tsval);
+	return timespec64_to_ns;
 }
 
 u64 _mali_osk_boot_time_get_ns(void)
 {
-	return (u64)ktime_to_ns(ktime_get_boottime());
+	return ktime_get_boottime_ns;
 }


### PR DESCRIPTION
Hi. I don't know is this 100% correct, but this changes resolved problem when im compiled libreelec for mali mali-utgard 450 , before i have break and error on kernel 5.6-rc6